### PR TITLE
Update ultimateListView.js

### DIFF
--- a/src/ultimateListView.js
+++ b/src/ultimateListView.js
@@ -688,7 +688,7 @@ const styles = StyleSheet.create({
     },
     paginationView: {
         flex: 0,
-        width: width,
+        //width: width,
         height: 55,
         flexDirection: 'row',
         justifyContent: 'center',


### PR DESCRIPTION
fix problem: pagination content not in the center when the  UltimateListView  is wrapped  with some element ( such as ScrollView )