### PR TITLE
workaround to fix stuck refresh on android + support prop-types package for React15.5 and above

### DIFF
--- a/src/refreshableScrollView.android.js
+++ b/src/refreshableScrollView.android.js
@@ -181,26 +181,29 @@ export default class RefreshableScrollView extends ScrollView {
     };
 
     renderRefreshHeader() {
-        if (this.props.customRefreshView) {
+        if (this.state.refreshTitle !== "Pull to refresh") {
+            if (this.props.customRefreshView) {
+                return (
+                    <View style={[defaultHeaderStyles.header, this.props.refreshViewStyle]}>
+                        {this.props.customRefreshView(this.state.refreshStatus, this._offsetY)}
+                    </View>
+                );
+            }
+
             return (
-                <View style={[defaultHeaderStyles.header, this.props.refreshViewStyle]}>
-                    {this.props.customRefreshView(this.state.refreshStatus, this._offsetY)}
+                <View style={[defaultHeaderStyles.header, this.props.refreshViewStyle, {height: this.state.showRefreshHeader ? this.props.refreshViewHeight : 0}]}>
+                    <View style={defaultHeaderStyles.status}>
+                        {this.renderSpinner()}
+                        <Text style={defaultHeaderStyles.statusTitle}>{this.state.refreshTitle}</Text>
+                    </View>
+                    {this.props.displayDate &&
+                    <Text
+                        style={[defaultHeaderStyles.date, this.props.dateStyle]}>{this.props.dateTitle + this.state.date}</Text>
+                    }
                 </View>
             );
         }
 
-        return (
-            <View style={[defaultHeaderStyles.header, this.props.refreshViewStyle, {height: this.state.showRefreshHeader ? this.props.refreshViewHeight : 0}]}>
-                <View style={defaultHeaderStyles.status}>
-                    {this.renderSpinner()}
-                    <Text style={defaultHeaderStyles.statusTitle}>{this.state.refreshTitle}</Text>
-                </View>
-                {this.props.displayDate &&
-                <Text
-                    style={[defaultHeaderStyles.date, this.props.dateStyle]}>{this.props.dateTitle + this.state.date}</Text>
-                }
-            </View>
-        );
     }
 
     renderSpinner() {

--- a/src/ultimateListView.js
+++ b/src/ultimateListView.js
@@ -1,4 +1,5 @@
 import React, {Component} from "react";
+import PropTypes from 'prop-types';
 import {
     ActivityIndicator,
     Dimensions,
@@ -85,63 +86,63 @@ export default class UltimateListView extends Component {
     };
 
     static propTypes = {
-        initialNumToRender: React.PropTypes.number,
-        horizontal: React.PropTypes.bool,
+        initialNumToRender: PropTypes.number,
+        horizontal: PropTypes.bool,
 
-        firstLoader: React.PropTypes.bool,
-        scrollEnabled: React.PropTypes.bool,
-        onFetch: React.PropTypes.func,
-        enableEmptySections: React.PropTypes.bool,
+        firstLoader: PropTypes.bool,
+        scrollEnabled: PropTypes.bool,
+        onFetch: PropTypes.func,
+        enableEmptySections: PropTypes.bool,
 
         //Custom ListView
-        header: React.PropTypes.func,
-        item: React.PropTypes.func,
-        sectionHeaderView: React.PropTypes.func,
-        paginationFetchingView: React.PropTypes.func,
-        paginationAllLoadedView: React.PropTypes.func,
-        paginationWaitingView: React.PropTypes.func,
-        emptyView: React.PropTypes.func,
-        separator: React.PropTypes.func,
+        header: PropTypes.func,
+        item: PropTypes.func,
+        sectionHeaderView: PropTypes.func,
+        paginationFetchingView: PropTypes.func,
+        paginationAllLoadedView: PropTypes.func,
+        paginationWaitingView: PropTypes.func,
+        emptyView: PropTypes.func,
+        separator: PropTypes.func,
 
         //Refreshable
-        refreshable: React.PropTypes.bool,
-        refreshableMode: React.PropTypes.string,
+        refreshable: PropTypes.bool,
+        refreshableMode: PropTypes.string,
 
         //RefreshControl
-        refreshableTitle: React.PropTypes.string,
-        refreshableColors: React.PropTypes.array,
-        refreshableProgressBackgroundColor: React.PropTypes.string,
-        refreshableSize: React.PropTypes.string,
-        refreshableTintColor: React.PropTypes.string,
-        customRefreshControl: React.PropTypes.func,
+        refreshableTitle: PropTypes.string,
+        refreshableColors: PropTypes.array,
+        refreshableProgressBackgroundColor: PropTypes.string,
+        refreshableSize: PropTypes.string,
+        refreshableTintColor: PropTypes.string,
+        customRefreshControl: PropTypes.func,
 
         //Advanced RefreshView
-        refreshableTitlePull: React.PropTypes.string,
-        refreshableTitleRefreshing: React.PropTypes.string,
-        refreshableTitleRelease: React.PropTypes.string,
-        customRefreshView: React.PropTypes.func,
-        customRefreshViewHeight: React.PropTypes.number,
-        displayDate: React.PropTypes.bool,
-        dateFormat: React.PropTypes.string,
-        dateTitle: React.PropTypes.string,
-        arrowImage: React.PropTypes.string,
+        refreshableTitlePull: PropTypes.string,
+        refreshableTitleRefreshing: PropTypes.string,
+        refreshableTitleRelease: PropTypes.string,
+        customRefreshView: PropTypes.func,
+        customRefreshViewHeight: PropTypes.number,
+        displayDate: PropTypes.bool,
+        dateFormat: PropTypes.string,
+        dateTitle: PropTypes.string,
+        arrowImage: PropTypes.string,
 
         //Pagination
-        pagination: React.PropTypes.bool,
-        autoPagination: React.PropTypes.bool,
-        allLoadedText: React.PropTypes.string,
+        pagination: PropTypes.bool,
+        autoPagination: PropTypes.bool,
+        allLoadedText: PropTypes.string,
 
         //Spinner
-        spinnerColor: React.PropTypes.string,
-        fetchingSpinnerSize: React.PropTypes.any,
-        waitingSpinnerSize: React.PropTypes.any,
-        waitingSpinnerText: React.PropTypes.string,
+        spinnerColor: PropTypes.string,
+        fetchingSpinnerSize: PropTypes.any,
+        waitingSpinnerSize: PropTypes.any,
+        waitingSpinnerText: PropTypes.string,
 
         //Pagination Button
-        paginationBtnText: React.PropTypes.string,
+        paginationBtnText: PropTypes.string,
 
         //GridView
-        numColumns: React.PropTypes.number
+        numColumns: PropTypes.number
     };
 
     constructor(props) {


### PR DESCRIPTION
it maybe not the best solution for the android stuck issue, but it served my needs,
and about the [prop-types ](https://facebook.github.io/react/docs/typechecking-with-proptypes.html) Facebook moved React.PropTypes into this new package since React 15.5 
